### PR TITLE
Account modified column

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ async function recurringUpdateLeaderboards() {
     b = true;
   });
 
-  console.log('updating cache');
+  console.log('Updating cache');
 
   while (true) {
     if (b) {

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -4,8 +4,22 @@ const { sleep } = require('./utils/sleep');
 const accountCreationSql = require('./queries/account-creation.sql');
 const scoreSql = require('./queries/score-calculate.sql');
 
+/**
+ * @typedef {'created_at_block_timestamp' | 'balance' | 'score'} AccountColumn
+ * @typedef {{ account_id: string; balance: string; score: number; created_at_block_timestamp: number; modified: number; }} AccountRecord
+ */
+
 class LeaderboardCache {
   constructor(cachePoolConnectionString, indexerPoolConnectionString) {
+    /** @type {Map<AccountColumn, (accountId: string) => Promise<any>>} */
+    this.cols = new Map(
+      Object.entries({
+        score: this.getAccountScore.bind(this),
+        balance: this.getAccountBalance.bind(this),
+        created_at_block_timestamp: this.getAccountCreated.bind(this),
+      }),
+    );
+
     this.cachePool = createPool(cachePoolConnectionString);
 
     this.indexerPool = createPool(indexerPoolConnectionString);
@@ -15,7 +29,7 @@ class LeaderboardCache {
     });
   }
 
-  async queryUpdatedAccountsFromIndexer(sinceBlockHeight) {
+  async queryNewAccountsFromIndexer(sinceBlockHeight) {
     const queryResult = await this.indexerPool.many(sql`
       select account_id,
         last_update_block_height
@@ -58,15 +72,33 @@ class LeaderboardCache {
     return { accounts, lastUpdateBlockHeight };
   }
 
-  /** @typedef {{ account_id: string; balance: string; score: number; }} AccountRecord */
   /** @type {() => Promise<AccountRecord[]>} */
   async queryAllAccountsFromCache() {
     try {
-      const res = await this.cachePool.many(sql`
+      return await this.cachePool.many(sql`
         select * from account
       `);
-      return res;
     } catch (err) {
+      // not yet initialized
+      return [];
+    }
+  }
+
+  /** @type {(limit: number) => Promise<AccountRecord[]>} */
+  async queryStaleAccountsFromCache(limit = 100) {
+    try {
+      return await this.cachePool.many(sql`
+        select
+          account_id,
+          balance::text,
+          score,
+          created_at_block_timestamp,
+          modified
+        from account
+        order by modified asc
+        limit ${limit}
+      `);
+    } catch (e) {
       // not yet initialized
       return [];
     }
@@ -137,16 +169,14 @@ class LeaderboardCache {
   }
 
   async loadAccounts() {
-    const cachedAccounts = await this.queryAllAccountsFromCache();
     const cachedLastUpdateBlockHeight =
       await this.queryLastUpdateBlockHeightFromCache();
 
-    const { accounts: accountsToUpdate, lastUpdateBlockHeight } =
-      await this.queryUpdatedAccountsFromIndexer(cachedLastUpdateBlockHeight);
+    const { accounts: newAccounts, lastUpdateBlockHeight } =
+      await this.queryNewAccountsFromIndexer(cachedLastUpdateBlockHeight);
 
     return {
-      cachedAccounts,
-      accountsToUpdate,
+      newAccounts,
       lastUpdateBlockHeight,
     };
   }
@@ -231,59 +261,6 @@ class LeaderboardCache {
     }
   }
 
-  async queryBalancesFromIndexerAndUpdate(accounts) {
-    const maxSimultaneousRequests = 10;
-
-    const balances = new Map();
-
-    let group = [];
-    for (let i = 0; i < accounts.length; i++) {
-      if (i > 0 && i % 1000 === 0) {
-        console.log('Leaderboard cache update', i);
-      }
-
-      if (group.length >= maxSimultaneousRequests) {
-        // console.log('group', i / maxSimultaneousRequests);
-
-        await Promise.all(
-          group.map(async (account) => {
-            try {
-              const [balance, score] = await Promise.all([
-                this.getAccountBalance(account),
-                this.getAccountScore(account),
-              ]);
-              await this.writeBalanceAndScore(account, balance, score);
-              // console.log('wrote balance and score for', account);
-              balances.set(account, balance);
-            } catch (e) {
-              // oh well
-              console.log('Unable to query and write balance for ', account, e);
-            }
-          }),
-        );
-
-        // be nice
-        // await sleep(100);
-
-        group = [];
-      }
-
-      group.push(accounts[i]);
-    }
-
-    return balances;
-  }
-
-  /** @type {() => Promise<string[]>} */
-  queryAccountsWithNullsFromCache() {
-    return this.cachePool.manyFirst(sql`
-      select account_id from account
-        where balance is null
-          or score is null
-          or created_at_block_timestamp is null
-    `);
-  }
-
   /** @type {() => Promise<string[]>} */
   queryAccountsWithNullBalanceFromCache() {
     return this.cachePool.manyFirst(sql`
@@ -305,6 +282,30 @@ class LeaderboardCache {
     return this.cachePool.manyFirst(sql`
       select account_id from account
         where created_at_block_timestamp is null
+    `);
+  }
+
+  /** @type {() => Promise<{ account_id: string; missing_columns: string; }[]>} */
+  queryAccountsWithNullsFromCache() {
+    const colNames = Array.from(this.cols.keys());
+
+    return this.cachePool.many(sql`
+      select account_id, concat(
+        ${sql.join(
+          colNames.map(
+            (col) =>
+              sql`case when ${sql.identifier([col])} is null then ${
+                col + ','
+              } else '' end`,
+          ),
+          sql`, `,
+        )}
+      ) as missing_columns
+      from account
+      where ${sql.join(
+        colNames.map((col) => sql`${sql.identifier([col])} is null`),
+        sql` or `,
+      )}
     `);
   }
 
@@ -348,53 +349,127 @@ class LeaderboardCache {
     }
   }
 
+  async updateAccount(
+    /** @type {string} */ accountId,
+    /** @type {AccountColumn[]} */ columnsToUpdate,
+  ) {
+    let promises = [];
+    let sets = [];
+
+    this.cols.forEach((getter, colName) => {
+      if (columnsToUpdate.includes(colName)) {
+        promises.push(
+          getter(accountId)
+            .then((value) => {
+              sets.push(sql`${sql.identifier([colName])} = ${value}`);
+            })
+            .catch((e) => {
+              // ignore
+              console.log('Could not get ' + colName + ' for ' + accountId);
+            }),
+        );
+      }
+    });
+
+    await Promise.all(promises);
+
+    if (sets.length) {
+      return this.cachePool.query(sql`
+        update account
+          set ${sql.join(sets, sql`, `)}
+          where account_id = ${accountId}
+      `);
+    } else {
+      return Promise.reject('No updates procured');
+    }
+  }
+
   async update() {
     console.log('Loading accounts...');
-    const { cachedAccounts, accountsToUpdate, lastUpdateBlockHeight } =
-      await this.loadAccounts();
+    const { newAccounts, lastUpdateBlockHeight } = await this.loadAccounts();
     console.log('Done loading accounts');
 
     console.log('Writing account ids...');
-    await this.writeAccountIds(accountsToUpdate);
+    await this.writeAccountIds(newAccounts);
     console.log('Done writing account ids');
-    // We don't much care to wait for this async function to complete
-    this.writeLastUpdateBlockHeight(lastUpdateBlockHeight);
 
-    const [updateBalanceAccounts, updateScoreAccounts, updateCreatedAccounts] =
-      await Promise.all([
-        this.queryAccountsWithNullBalanceFromCache(),
-        this.queryAccountsWithNullScoreFromCache(),
-        this.queryAccountsWithNullCreatedFromCache(),
-      ]);
+    console.log('Writing last update block height...');
+    // Note: lastUpdateBlockHeight is not used for anything anymore, BUT it
+    // will be useful again once we are able to query the indexer for accounts
+    // that have been updated after a particular block (such queries currently
+    // time out on the public indexer db)
+    await this.writeLastUpdateBlockHeight(lastUpdateBlockHeight);
+    console.log('Done writing last update block height');
 
-    console.log('Null balance:', updateBalanceAccounts.length);
-    console.log('Null score:', updateScoreAccounts.length);
-    console.log('Null created:', updateCreatedAccounts.length);
+    console.log('Loading accounts with nulls...');
+    const accountsWithNulls = await this.queryAccountsWithNullsFromCache();
+    console.log('Done loading accounts with nulls');
 
-    console.log('Updates to new/stale accounts', accountsToUpdate.length);
+    console.log(
+      'Updating ' + accountsWithNulls.length + ' accounts with nulls...',
+    );
 
-    await Promise.all([
-      this.queryAndUpdate(
-        'Balance',
-        updateBalanceAccounts.concat(accountsToUpdate),
-        (account) => this.getAccountBalance(account),
-        (account, value) => this.writeBalance(account, value),
-      ),
-      this.queryAndUpdate(
-        'Score',
-        updateScoreAccounts.concat(accountsToUpdate),
-        (account) => this.getAccountScore(account),
-        (account, value) => this.writeScore(account, value),
-      ),
-      this.queryAndUpdate(
-        'Created',
-        updateCreatedAccounts.concat(accountsToUpdate),
-        (account) => this.getAccountCreated(account),
-        (account, value) => this.writeCreated(account, value),
-      ),
-    ]);
+    const groupSize = 10;
 
-    console.log('Done writing updates.');
+    for (let i = 0; i < accountsWithNulls.length; i += groupSize) {
+      console.log(
+        `Accounts with nulls: ${i} / ${accountsWithNulls.length} (${(
+          (i / accountsWithNulls.length) *
+          100
+        ).toFixed(2)}%)`,
+      );
+
+      await Promise.all(
+        accountsWithNulls.slice(i, groupSize).map((record) =>
+          this.updateAccount(
+            record.account_id,
+
+            // Trailing comma means we have an empty element at the end of the
+            // array, but it doesn't matter
+            record.missing_columns.split(','),
+          ),
+        ),
+      );
+    }
+
+    console.log('Done updating accounts with nulls');
+    console.log('Updating stale accounts...');
+
+    let maxModified = 0;
+    let i = 0;
+    const day = 1000 * 60 * 60 * 24;
+
+    // Accounts last modified earlier than staleTime should be updated
+    const staleTime = day / 2;
+
+    while (Date.now() - maxModified > staleTime) {
+      console.log('Stale accounts group ' + i);
+      console.log('Loading stale accounts...');
+      const staleAccounts = await this.queryStaleAccountsFromCache(10);
+      console.log('Done loading stale accounts');
+
+      console.log('Updating ' + staleAccounts.length + ' stale accounts...');
+      await Promise.all(
+        staleAccounts.map((account) => {
+          maxModified = Math.max(maxModified, account.modified);
+          return this.updateAccount(account.account_id, [
+            'balance',
+            'score',
+          ]).catch((e) => {
+            console.log('Could not update ' + account.account_id, e);
+          });
+        }),
+      );
+      console.log('Done updating ' + staleAccounts.length + ' stale accounts');
+
+      console.log('max modified', maxModified, new Date(maxModified));
+
+      i++;
+    }
+
+    console.log('Done updating stale accounts');
+
+    console.log('Done writing updates');
   }
 }
 

--- a/migrations/20211008192100-account-modified.js
+++ b/migrations/20211008192100-account-modified.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20211008192100-account-modified-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20211008192100-account-modified-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20211008192100-account-modified-down.sql
+++ b/migrations/sqls/20211008192100-account-modified-down.sql
@@ -1,0 +1,4 @@
+drop trigger if exists update_account_modified on account;
+drop function if exists update_modified_column;
+
+alter table account drop column modified;

--- a/migrations/sqls/20211008192100-account-modified-up.sql
+++ b/migrations/sqls/20211008192100-account-modified-up.sql
@@ -1,0 +1,16 @@
+ALTER TABLE IF EXISTS account
+  ADD COLUMN modified timestamp without time zone DEFAULT current_timestamp;
+
+-- https://stackoverflow.com/a/26284695
+create or replace function update_modified_column()
+returns trigger as $$
+begin
+  new.modified = now();
+  return new;
+end;
+$$ language 'plpgsql';
+
+create trigger update_account_modified
+  before update on account
+  for each row
+  execute procedure update_modified_column();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node -r dotenv/config ./index.js",
+    "start": "node --trace-warnings -r dotenv/config ./index.js",
     "start:prod": "node -r dotenv/config dist",
     "build": "esbuild index.js --platform=node --bundle --outfile=dist/index.js --target=node14 --external:canvas --external:pg"
   },


### PR DESCRIPTION
### 🤔 Why?
- clean up old/unused/disorganized code
- slightly more standardized/generic (and easier-to-use) account updating functions
- the `last_update_block_height` column in the indexer db is not updated every time the account is updated, so it doesn't actually do what it was being used for

### 🛠 What I changed:
- new `modified` column for each account row
- `updateAccount` function will update columns according to `this.cols`
- better/clearer logging in `update`

### 🚦 Functional Testing Results:
- eyy it still works I think
- we need tests I guess
