### PR TITLE
Add an endpoint to fetch the top weekly wallets based on transactions 

### DIFF
--- a/src/queries/Params.ts
+++ b/src/queries/Params.ts
@@ -1,5 +1,13 @@
-export interface Params {
-  account_id: string;
+export interface TimestampRange {
   after_block_timestamp?: number;
   before_block_timestamp?: number;
+}
+
+export interface LimitAndOffset {
+  limit?: number,
+  offset?: number
+}
+
+export interface Params extends TimestampRange, LimitAndOffset{
+  account_id: string;
 }

--- a/src/queries/Params.ts
+++ b/src/queries/Params.ts
@@ -3,11 +3,6 @@ export interface TimestampRange {
   before_block_timestamp?: number;
 }
 
-export interface LimitAndOffset {
-  limit?: number,
-  offset?: number
-}
-
-export interface Params extends TimestampRange, LimitAndOffset{
+export interface Params extends TimestampRange {
   account_id: string;
 }

--- a/src/queries/most-active-wallet-within-range.sql.ts
+++ b/src/queries/most-active-wallet-within-range.sql.ts
@@ -1,5 +1,4 @@
 import { sql } from 'slonik';
-import { Params } from './Params';
 
 export default () => {
   const currentDate = new Date();

--- a/src/queries/most-active-wallet-within-range.sql.ts
+++ b/src/queries/most-active-wallet-within-range.sql.ts
@@ -25,14 +25,13 @@ export default (params: Params) => {
 
   return sql`
     select
-      action_receipt_actions.receipt_predecessor_account_id as account_id
+      signer_account_id as account_id,
+      count(1) as number_of_transactions
     from
-      action_receipt_actions 
-    inner join 
-      accounts on accounts.account_id = action_receipt_actions.receipt_predecessor_account_id
-    group by
-      action_receipt_actions.receipt_predecessor_account_id
+      transactions 
     where ${sql.join(conditions, sql` and `)}
+    group by
+      signer_account_id
     ${params.limit !== undefined ? sql`limit ${params.limit}` : sql`limit 5`}
     ${params.offset !== undefined ? sql`offset ${params.offset}` : sql``}
   `;

--- a/src/queries/most-active-wallet-within-range.sql.ts
+++ b/src/queries/most-active-wallet-within-range.sql.ts
@@ -1,29 +1,40 @@
 import { sql } from 'slonik';
+import { TimestampRange } from './Params';
 
-export default () => {
-  const currentDate = new Date();
-  const today = currentDate.getDate();
-  const dayOfTheWeek = currentDate.getDay();
-  const blockchain_timestamp_precision = 1000000; // miliseconds to nanoseconds
+export default (range: TimestampRange) => {
+  const conditions = [];
 
-  const startOfWeek = new Date().setDate(today - (dayOfTheWeek || 7));
-  const startOfWeekTimeStamp = new Date(startOfWeek).getTime() * blockchain_timestamp_precision;
-  const currentDateTimeStamp = currentDate.getTime() * blockchain_timestamp_precision;
+  if (
+    range.after_block_timestamp !== undefined &&
+    range.after_block_timestamp > 0
+  ) {
+    conditions.push(
+      sql`transactions.block_timestamp >= ${range.after_block_timestamp}`,
+    );
+  }
 
+  if (
+    range.before_block_timestamp !== undefined &&
+    range.before_block_timestamp > 0
+  ) {
+    conditions.push(
+      sql`transactions.block_timestamp <= ${range.before_block_timestamp}`,
+    );
+  }
+
+  // Currently, we limit this to only the top few, but once new requirements
+  // come in, this should be revisited. Another reason why we hardcode this
+  // is to help dissuade curious people from overworking the indexer.
   return sql`
     select
       signer_account_id as account_id,
       count(1) as number_of_transactions
     from
       transactions 
-    where 
-      block_timestamp >= ${startOfWeekTimeStamp}
-      and block_timestamp <= ${currentDateTimeStamp}
+    where ${sql.join(conditions, sql` and `)}
     group by
       signer_account_id
     order by number_of_transactions desc
-    -- currently, we limit this to only the top 5 but once new requirements come in, this should be revisited
-    -- another reason why we hardcode this is to prevent curious people from overworking the mainnet explorer database and bring it down
-    limit 5
+    limit 15
   `;
-}
+};

--- a/src/queries/most-active-wallet-within-range.sql.ts
+++ b/src/queries/most-active-wallet-within-range.sql.ts
@@ -1,0 +1,39 @@
+import { sql } from 'slonik';
+import { Params } from './Params';
+
+export default (params: Params) => {
+
+  const conditions = [];
+
+  if (
+    params.after_block_timestamp !== undefined &&
+    params.after_block_timestamp > 0
+  ) {
+    conditions.push(
+      sql`transactions.block_timestamp >= ${params.after_block_timestamp}`,
+    );
+  }
+
+  if (
+    params.before_block_timestamp !== undefined &&
+    params.before_block_timestamp > 0
+  ) {
+    conditions.push(
+      sql`transactions.block_timestamp <= ${params.before_block_timestamp}`,
+    );
+  }
+
+  return sql`
+    select
+      action_receipt_actions.receipt_predecessor_account_id as account_id
+    from
+      action_receipt_actions 
+    inner join 
+      accounts on accounts.account_id = action_receipt_actions.receipt_predecessor_account_id
+    group by
+      action_receipt_actions.receipt_predecessor_account_id
+    where ${sql.join(conditions, sql` and `)}
+    ${params.limit !== undefined ? sql`limit ${params.limit}` : sql`limit 5`}
+    ${params.offset !== undefined ? sql`offset ${params.offset}` : sql``}
+  `;
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -152,7 +152,8 @@ export default [
     poll: 1 * HOUR,
   },
   {
-    path: 'top-weekly',
-    query: mostActiveWalletSql
+    path: 'transactions/top-range',
+    query: mostActiveWalletSql,
+    poll: 15 * MINUTE,
   }
 ];

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -24,7 +24,7 @@ import sentTransactionCountSql from './queries/sent-transaction-count.sql';
 import topAccountsSql from './queries/top-accounts.sql';
 import totalReceivedSql from './queries/total-received.sql';
 import totalSentSql from './queries/total-sent.sql';
-import mostActiveWalleySql from './queries/most-active-wallet-within-range.sql';
+import mostActiveWalletSql from './queries/most-active-wallet-within-range.sql';
 
 const SECOND = 1000,
   MINUTE = 60 * SECOND,
@@ -153,6 +153,6 @@ export default [
   },
   {
     path: 'top-weekly',
-    query: mostActiveWalleySql
+    query: mostActiveWalletSql
   }
 ];

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -24,6 +24,7 @@ import sentTransactionCountSql from './queries/sent-transaction-count.sql';
 import topAccountsSql from './queries/top-accounts.sql';
 import totalReceivedSql from './queries/total-received.sql';
 import totalSentSql from './queries/total-sent.sql';
+import mostActiveWalleySql from './queries/most-active-wallet-within-range.sql';
 
 const SECOND = 1000,
   MINUTE = 60 * SECOND,
@@ -150,4 +151,8 @@ export default [
     db: 'cache',
     poll: 1 * HOUR,
   },
+  {
+    path: 'top-weekly',
+    query: mostActiveWalleySql
+  }
 ];

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import accessKeysSql from './queries/access-keys.sql';
 import accountActivityDistributionSql from './queries/account-activity-distribution.sql';
 import accountCreationSql from './queries/account-creation.sql';
@@ -14,6 +15,7 @@ import distinctReceiversSql from './queries/distinct-receivers.sql';
 import distinctSendersSql from './queries/distinct-senders.sql';
 import gasSpentSql from './queries/gas-spent.sql';
 import gasTokensSpentSql from './queries/gas-tokens-spent.sql';
+import mostActiveWalletSql from './queries/most-active-wallet-within-range.sql';
 import newAccountsCountSql from './queries/new-accounts-count.sql';
 import newAccountsListSql from './queries/new-accounts-list.sql';
 import receivedTransactionCountSql from './queries/received-transaction-count.sql';
@@ -24,7 +26,6 @@ import sentTransactionCountSql from './queries/sent-transaction-count.sql';
 import topAccountsSql from './queries/top-accounts.sql';
 import totalReceivedSql from './queries/total-received.sql';
 import totalSentSql from './queries/total-sent.sql';
-import mostActiveWalletSql from './queries/most-active-wallet-within-range.sql';
 
 const SECOND = 1000,
   MINUTE = 60 * SECOND,
@@ -152,8 +153,14 @@ export default [
     poll: 1 * HOUR,
   },
   {
-    path: 'transactions/top-range',
-    query: mostActiveWalletSql,
+    path: 'leaderboard-transactions-week',
+    query: () => {
+      const oneWeekAgo =
+        DateTime.now().minus({ weeks: 1 }).toMillis() * 1_000_000;
+      return mostActiveWalletSql({
+        after_block_timestamp: oneWeekAgo,
+      });
+    },
     poll: 15 * MINUTE,
-  }
+  },
 ];


### PR DESCRIPTION
### 🤔 Why?

- In order to help NEARWeek, we want to add several statistics to stats.gallery to extend insights within the NEAR blockchain 

### 🛠 What I changed:

- Added a new endpoint for fetching the top 5 weekly accounts based on transactions

### 🚦 Functional Testing Results:

- I validated the generated date by printing them out and inputting them here: https://www.epochconverter.com/
- I validated the ordering of the results as descending based on the object returned by the endpoint
