### PR TITLE
Feature: Add Invalidator for Transactions

### DIFF
--- a/src/crons/index.ts
+++ b/src/crons/index.ts
@@ -2,6 +2,7 @@ import { DatabasePool } from 'slonik';
 import { CronJob } from './CronJob';
 import { createCacheJob } from './cache';
 import OnChainTransactionsCache from './onChainTransactions';
+import TransactionInvalidator from './transactionInvalidator';
 
 export interface CronJobSpec {
   environment: Record<string, string>;
@@ -18,5 +19,9 @@ export default function initCronJobs(spec: CronJobSpec): CronJob[] {
     environment: environment,
   });
 
-  return [createCacheJob(spec), onChainTransactions];
+  const transactionInvalidator = TransactionInvalidator({
+    localCachePool: cachePool,
+  });
+
+  return [createCacheJob(spec), onChainTransactions, transactionInvalidator];
 }

--- a/src/crons/transactionInvalidator.ts
+++ b/src/crons/transactionInvalidator.ts
@@ -1,0 +1,31 @@
+import { DatabasePool, sql } from 'slonik';
+import { CronJob } from './CronJob';
+import { DAY } from '../utils/constants';
+
+type TransactionInvalidatorCacheSpec = {
+  localCachePool: DatabasePool;
+};
+
+export default (spec: TransactionInvalidatorCacheSpec): CronJob => {
+  const cronName = 'TRANSACTION_INVALIDATOR';
+  const { localCachePool } = spec;
+
+  const run = async () => {
+    // Add a 1 day allowance before invalidating transactions
+    const lastSevenDays = Date.now() - DAY * 8;
+    const lastSevenDaysEpoch = lastSevenDays * 1_000_000;
+
+    const res = await localCachePool.query(sql`
+      delete from on_chain_transaction where block_timestamp < ${lastSevenDaysEpoch}
+    `);
+
+    console.log('successfully deleted on_chain_transaction', res);
+  };
+
+  return Object.freeze({
+    isEnabled: true,
+    cronName,
+    schedule: '0 0 * * *', // every day
+    run,
+  });
+};


### PR DESCRIPTION
### 🤔 Why?

- We recently added a way to store on chain transactions into our postgres instance
- However, currently it is unbounded and is concerning in the point of view of the application as it is not the initial goal of the project
- In order to combat this, we will want to add a way to put a bound on this so that we don't pay for unnecessary data on our side

### 🛠 What I changed:

- Added a cron job that will run once everyday to remove transactions that we don't intend to query

### 🚦 Functional Testing Results:

- Tested the query locally and made sure that only the records we want to remove are affected
