### PR TITLE
Feature: Action Receipt Invalidator

### DIFF
--- a/src/crons/appActionReceiptsInvalidator.ts
+++ b/src/crons/appActionReceiptsInvalidator.ts
@@ -1,0 +1,31 @@
+import { DatabasePool, sql } from 'slonik';
+import { CronJob } from './CronJob';
+import { DAY } from '../utils/constants';
+
+type TransactionInvalidatorCacheSpec = {
+  localCachePool: DatabasePool;
+};
+
+export default (spec: TransactionInvalidatorCacheSpec): CronJob => {
+  const cronName = 'APP_ACTION_RECEIPTS_INVALIDATOR';
+  const { localCachePool } = spec;
+
+  const run = async () => {
+    // Add a 1 day allowance before invalidating transactions
+    const lastSevenDays = Date.now() - DAY * 8;
+    const lastSevenDaysEpoch = lastSevenDays * 1_000_000;
+
+    const res = await localCachePool.query(sql`
+      delete from action_receipt_action where block_timestamp < ${lastSevenDaysEpoch}
+    `);
+
+    console.log('successfully deleted action_receipt_action', res);
+  };
+
+  return Object.freeze({
+    isEnabled: true,
+    cronName,
+    schedule: '*/1 * * * *', // every day
+    run,
+  });
+};

--- a/src/crons/appActionReceiptsInvalidator.ts
+++ b/src/crons/appActionReceiptsInvalidator.ts
@@ -16,7 +16,7 @@ export default (spec: TransactionInvalidatorCacheSpec): CronJob => {
     const lastSevenDaysEpoch = lastSevenDays * 1_000_000;
 
     const res = await localCachePool.query(sql`
-      delete from action_receipt_action where block_timestamp < ${lastSevenDaysEpoch}
+      delete from action_receipt_action where receipt_included_in_block_timestamp < ${lastSevenDaysEpoch}
     `);
 
     console.log('successfully deleted action_receipt_action', res);
@@ -25,7 +25,7 @@ export default (spec: TransactionInvalidatorCacheSpec): CronJob => {
   return Object.freeze({
     isEnabled: true,
     cronName,
-    schedule: '*/1 * * * *', // every day
+    schedule: '0 0 * * *', // every day
     run,
   });
 };

--- a/src/crons/index.ts
+++ b/src/crons/index.ts
@@ -3,6 +3,7 @@ import { CronJob } from './CronJob';
 import { createCacheJob } from './cache';
 import OnChainTransactionsCache from './onChainTransactions';
 import TransactionInvalidator from './transactionInvalidator';
+import AppActionInvalidator from './appActionReceiptsInvalidator';
 import AppTransactionReceiptCache from './appActionReceipts';
 
 export interface CronJobSpec {
@@ -24,6 +25,10 @@ export default function initCronJobs(spec: CronJobSpec): CronJob[] {
     localCachePool: cachePool,
   });
 
+  const appActionInvalidator = AppActionInvalidator({
+    localCachePool: cachePool,
+  });
+
   const appReceiptActions = AppTransactionReceiptCache({
     localCachePool: cachePool,
     indexerCachepool: indexerPool,
@@ -35,5 +40,6 @@ export default function initCronJobs(spec: CronJobSpec): CronJob[] {
     onChainTransactions,
     transactionInvalidator,
     appReceiptActions,
+    appActionInvalidator,
   ];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ const indexerPool = createPool(indexerDatabaseString, {
 process.on('exit', async () => {
   try {
     await Promise.all([await cachePool.end(), await indexerPool.end()]);
-    console.log('successfully closed database connections');
+    console.log('Successfully closed database connections');
   } catch (error) {
     console.log('Error closing cache connection pools', error);
   }


### PR DESCRIPTION
### 🤔 Why?

- We recently added a way to store app_receipt_actions into our postgres instance
- However, currently it is unbounded and is concerning in the point of view of the application as it is not the initial goal of the project
- In order to combat this, we will want to add a way to put a bound on this so that we don't pay for unnecessary data on our side

### 🛠 What I changed:

- Added a cron job that will run once everyday to remove transactions that we don't intend to query

### 🚦 Functional Testing Results:

- Tested the query locally and made sure that only the records we want to remove are affected