### PR TITLE
Fix: Add crons to testnet

### DIFF
--- a/migrations/20220129123236-add-crons-to-testnet.js
+++ b/migrations/20220129123236-add-crons-to-testnet.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20220129123236-add-crons-to-testnet-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20220129123236-add-crons-to-testnet-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20220129123236-add-crons-to-testnet-down.sql
+++ b/migrations/sqls/20220129123236-add-crons-to-testnet-down.sql
@@ -1,0 +1,3 @@
+update last_update set cron_name = 'TRANSACTIONS_CACHE' where cron_name = 'MAINNET_TRANSACTIONS_CACHE';
+update last_update set cron_name = 'APP_ACTIONS_RECEIPT' where cron_name = 'MAINNET_APP_ACTIONS_RECEIPT';
+update last_update set cron_name = 'ACCOUNTS_CACHE' where cron_name = 'MAINNET_ACCOUNTS_CACHE';

--- a/migrations/sqls/20220129123236-add-crons-to-testnet-up.sql
+++ b/migrations/sqls/20220129123236-add-crons-to-testnet-up.sql
@@ -1,0 +1,3 @@
+update last_update set cron_name = 'MAINNET_TRANSACTIONS_CACHE' where cron_name = 'TRANSACTIONS_CACHE';
+update last_update set cron_name = 'MAINNET_APP_ACTIONS_RECEIPT' where cron_name = 'APP_ACTIONS_RECEIPT';
+update last_update set cron_name = 'MAINNET_ACCOUNTS_CACHE' where cron_name = 'ACCOUNTS_CACHE';

--- a/src/crons/appActionReceipts.ts
+++ b/src/crons/appActionReceipts.ts
@@ -6,6 +6,7 @@ type AppActionReceiptsSpec = {
   localCachePool: DatabasePool;
   indexerCachepool: DatabasePool;
   environment: Record<string, string>;
+  nearNetwork: string;
 };
 
 interface ActionReceiptActionProps {
@@ -19,8 +20,8 @@ interface ActionReceiptActionProps {
 }
 
 export default (spec: AppActionReceiptsSpec): CronJob => {
-  const { localCachePool, indexerCachepool } = spec;
-  const cronName = 'APP_ACTIONS_RECEIPT';
+  const { localCachePool, indexerCachepool, nearNetwork } = spec;
+  const cronName = `${nearNetwork.toUpperCase()}_APP_ACTIONS_RECEIPT`;
 
   const run = async () => {
     const startEpoch = await (async (): Promise<number> => {

--- a/src/crons/appActionReceiptsInvalidator.ts
+++ b/src/crons/appActionReceiptsInvalidator.ts
@@ -5,11 +5,12 @@ import { DAY } from '../utils/constants';
 type TransactionInvalidatorCacheSpec = {
   localCachePool: DatabasePool;
   environment: Record<string, string>;
+  nearNetwork: string;
 };
 
 export default (spec: TransactionInvalidatorCacheSpec): CronJob => {
-  const cronName = 'APP_ACTION_RECEIPTS_INVALIDATOR';
-  const { localCachePool } = spec;
+  const { localCachePool, nearNetwork } = spec;
+  const cronName = `${nearNetwork.toUpperCase()}_APP_ACTION_RECEIPTS_INVALIDATOR`;
 
   const run = async () => {
     // Add a 1 day allowance before invalidating transactions

--- a/src/crons/index.ts
+++ b/src/crons/index.ts
@@ -10,31 +10,36 @@ export interface CronJobSpec {
   environment: Record<string, string>;
   cachePool: DatabasePool;
   indexerPool: DatabasePool;
+  nearNetwork: string;
 }
 
 export default function initCronJobs(spec: CronJobSpec): CronJob[] {
-  const { environment, cachePool, indexerPool } = spec;
+  const { environment, cachePool, indexerPool, nearNetwork } = spec;
 
   const onChainTransactions = OnChainTransactionsCache({
     localCachePool: cachePool,
     indexerCachepool: indexerPool,
     environment: environment,
+    nearNetwork,
   });
 
   const transactionInvalidator = TransactionInvalidator({
     localCachePool: cachePool,
     environment: environment,
+    nearNetwork,
   });
 
   const appActionInvalidator = AppActionInvalidator({
     localCachePool: cachePool,
     environment: environment,
+    nearNetwork
   });
 
   const appReceiptActions = AppTransactionReceiptCache({
     localCachePool: cachePool,
     indexerCachepool: indexerPool,
     environment: environment,
+    nearNetwork,
   });
 
   return [

--- a/src/crons/onChainTransactions.ts
+++ b/src/crons/onChainTransactions.ts
@@ -6,6 +6,7 @@ type OnChainTransactionsCacheSpec = {
   localCachePool: DatabasePool;
   indexerCachepool: DatabasePool;
   environment: Record<string, string>;
+  nearNetwork: string;
 };
 
 interface txnProps {
@@ -33,8 +34,8 @@ type localCacheTxn = Omit<
 >;
 
 export default (spec: OnChainTransactionsCacheSpec): CronJob => {
-  const { localCachePool, indexerCachepool } = spec;
-  const cronName = 'TRANSACTIONS_CACHE';
+  const { localCachePool, indexerCachepool, nearNetwork } = spec;
+  const cronName = `${nearNetwork.toUpperCase()}_TRANSACTIONS_CACHE`;
 
   const run = async () => {
     // STEP 1: determine the starting epoch — if this is the first time for the job to run, create a new entry

--- a/src/crons/transactionInvalidator.ts
+++ b/src/crons/transactionInvalidator.ts
@@ -5,11 +5,12 @@ import { DAY } from '../utils/constants';
 type TransactionInvalidatorCacheSpec = {
   localCachePool: DatabasePool;
   environment: Record<string, string>;
+  nearNetwork: string;
 };
 
 export default (spec: TransactionInvalidatorCacheSpec): CronJob => {
-  const cronName = 'TRANSACTION_INVALIDATOR';
-  const { localCachePool } = spec;
+  const { localCachePool, nearNetwork } = spec;
+  const cronName = `${nearNetwork.toUpperCase()}_TRANSACTION_INVALIDATOR`;
 
   const run = async () => {
     // Add a 1 day allowance before invalidating transactions


### PR DESCRIPTION
### 🤔 Why?

- Initially we were just running crons against the mainnet
- This left the leaderboards for the testnet not functional

### 🛠 What I changed:

- Added a migration to migrate the last_update records to the correct namespace
- Made the crons ability to accept near network

### 🚦 Functional Testing Results:

- Tested locally and made sure that the crons are running against the right environment and database is being filled with the expected information

### Gotchas:
1. Seems like the `account` table is not yet ready for this. 
